### PR TITLE
refactor: centralize YouTube API requests

### DIFF
--- a/scripts/verifyCommentService.mjs
+++ b/scripts/verifyCommentService.mjs
@@ -11,7 +11,10 @@ const outputPath = path.join(outputDirectory, 'comment-service-verification.cjs'
 
 await build({
 	stdin: {
-		contents: `export { CommentService, CommentServiceError } from './src/services/commentService.ts';`,
+		contents: `
+			export { CommentService, CommentServiceError } from './src/services/commentService.ts';
+			export { YouTubeApiClient } from './src/services/youtubeApiClient.ts';
+		`,
 		resolveDir: process.cwd(),
 		sourcefile: 'comment-service-verification-entry.ts',
 	},
@@ -26,14 +29,14 @@ await build({
 				path: 'obsidian',
 				namespace: 'verification',
 			}));
-			builder.onResolve({ filter: /^\.\.\/auth$/ }, () => ({
-				path: 'auth',
+			builder.onResolve({ filter: /^src\/debug$/ }, () => ({
+				path: 'debug',
 				namespace: 'verification',
 			}));
 			builder.onLoad({ filter: /.*/, namespace: 'verification' }, (args) => ({
 				contents: args.path === 'obsidian'
 					? `export const requestUrl = (request) => globalThis.requestUrl(request);`
-					: `export const getValidAccessToken = async () => 'access-token';`,
+					: `export const debugLogger = { api() {} };`,
 				loader: 'js',
 			}));
 		},
@@ -41,7 +44,7 @@ await build({
 });
 
 const require = createRequire(import.meta.url);
-const { CommentService, CommentServiceError } = require(outputPath);
+const { CommentService, CommentServiceError, YouTubeApiClient } = require(outputPath);
 const requests = [];
 let commentsResponse = {
 	status: 200,
@@ -74,8 +77,12 @@ globalThis.requestUrl = async (request) => {
 	}
 	return commentsResponse;
 };
+globalThis.window = {
+	setTimeout: globalThis.setTimeout.bind(globalThis),
+	clearTimeout: globalThis.clearTimeout.bind(globalThis),
+};
 
-const service = new CommentService({ googleClientId: 'client-id' });
+const service = new CommentService(new YouTubeApiClient(async () => 'access-token'));
 const result = await service.fetchVideoComments('video-id', new AbortController().signal);
 assert.equal(result.comments.length, 1);
 assert.equal(result.comments[0].id, 'comment-id');

--- a/scripts/verifyGoogleClientSecretAuth.mjs
+++ b/scripts/verifyGoogleClientSecretAuth.mjs
@@ -12,7 +12,7 @@ const outputPath = path.join(outputDirectory, 'auth-verification.cjs');
 await build({
 	stdin: {
 		contents: `
-			export { handleGoogleLogin, refreshAccessToken } from './src/auth.ts';
+			export { handleGoogleLogin, refreshAccessToken, getValidAccessToken } from './src/auth.ts';
 			export { googleTokenStorageService } from './src/services/googleTokenStorageService.ts';
 		`,
 		resolveDir: process.cwd(),
@@ -76,7 +76,12 @@ const secrets = new Map([
 	['geulo-google-refresh-token', 'refresh-from-storage'],
 ]);
 const localStorage = new FakeLocalStorage();
-globalThis.window = { localStorage, open() {} };
+globalThis.window = {
+	localStorage,
+	open() {},
+	setTimeout: globalThis.setTimeout.bind(globalThis),
+	clearTimeout: globalThis.clearTimeout.bind(globalThis),
+};
 
 let oauthCallback;
 let createServerCount = 0;
@@ -142,7 +147,7 @@ globalThis.requestUrl = async (request) => {
 
 try {
 	const require = createRequire(import.meta.url);
-	const { handleGoogleLogin, refreshAccessToken, googleTokenStorageService } = require(outputPath);
+	const { handleGoogleLogin, refreshAccessToken, getValidAccessToken, googleTokenStorageService } = require(outputPath);
 	googleTokenStorageService.initialize(new FakeSecretStorage(secrets));
 	let loginSuccessCount = 0;
 	const handleLoginSuccess = () => {
@@ -173,6 +178,64 @@ try {
 	const parsedBody = JSON.parse(refreshRequestBody);
 	assert.equal(parsedBody.client_secret, 'secret-from-storage');
 	assert.notEqual(parsedBody.client_secret, 'settings-secret');
+
+	secrets.set('geulo-google-access-token', '');
+	localStorage.setItem('googleYtbLikedVideoExpirationTime', '0');
+	let concurrentRefreshCount = 0;
+	let resolveConcurrentRefresh;
+	globalThis.requestUrl = () => {
+		concurrentRefreshCount += 1;
+		return new Promise((resolve) => { resolveConcurrentRefresh = resolve; });
+	};
+	const concurrentTokens = Array.from({ length: 6 }, () => getValidAccessToken('client-id'));
+	assert.equal(concurrentRefreshCount, 1);
+	resolveConcurrentRefresh({ status: 200, json: { access_token: 'shared-access', expires_in: 3600 } });
+	assert.deepEqual(await Promise.all(concurrentTokens), Array(6).fill('shared-access'));
+	assert.equal(googleTokenStorageService.getAccessToken(), 'shared-access');
+
+	secrets.set('geulo-google-access-token', '');
+	localStorage.setItem('googleYtbLikedVideoExpirationTime', '0');
+	globalThis.requestUrl = async () => ({ status: 503, json: { error: 'unavailable' } });
+	await assert.rejects(getValidAccessToken('client-id'), /503/);
+	globalThis.requestUrl = async () => ({ status: 200, json: { access_token: 'retry-access', expires_in: 3600 } });
+	assert.equal(await getValidAccessToken('client-id'), 'retry-access');
+
+	secrets.set('geulo-google-access-token', '');
+	localStorage.setItem('googleYtbLikedVideoExpirationTime', '0');
+	let resolveTimedOutRefresh;
+	globalThis.requestUrl = () => new Promise((resolve) => { resolveTimedOutRefresh = resolve; });
+	const originalSetTimeout = globalThis.window.setTimeout;
+	const originalClearTimeout = globalThis.window.clearTimeout;
+	globalThis.window.setTimeout = (callback) => {
+		queueMicrotask(callback);
+		return 1;
+	};
+	globalThis.window.clearTimeout = () => {};
+	await assert.rejects(getValidAccessToken('client-id'), /timed out/);
+	globalThis.window.setTimeout = originalSetTimeout;
+	globalThis.window.clearTimeout = originalClearTimeout;
+	resolveTimedOutRefresh({ status: 200, json: { access_token: 'late-access', expires_in: 3600 } });
+	await new Promise((resolve) => setImmediate(resolve));
+	assert.equal(googleTokenStorageService.getAccessToken(), '');
+
+	let resolveStaleRefresh;
+	globalThis.requestUrl = () => new Promise((resolve) => { resolveStaleRefresh = resolve; });
+	const staleRefresh = getValidAccessToken('client-id');
+	secrets.set('geulo-google-refresh-token', 'replacement-refresh');
+	resolveStaleRefresh({ status: 200, json: { access_token: 'stale-access', expires_in: 3600 } });
+	await assert.rejects(staleRefresh, /changed during token refresh/);
+	assert.equal(googleTokenStorageService.getAccessToken(), '');
+	secrets.set('geulo-google-refresh-token', 'refresh-from-storage');
+	globalThis.requestUrl = async (request) => {
+		const requestBody = String(request.body);
+		if (requestBody.includes('grant_type=authorization_code')) {
+			loginRequestUrl = String(request.url);
+			loginRequestBody = requestBody;
+			return loginResponse;
+		}
+		refreshRequestBody = requestBody;
+		return { status: 200, json: { access_token: 'refreshed-access', expires_in: 3600 } };
+	};
 
 	loginResponse = {
 		status: 400,

--- a/scripts/verifySubscriptionStorage.mjs
+++ b/scripts/verifySubscriptionStorage.mjs
@@ -1,3 +1,4 @@
+/* global globalThis */
 import assert from 'node:assert/strict';
 import { access, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -13,6 +14,7 @@ try {
 		stdin: {
 			contents: `export { SubscriptionStorageService } from './src/services/subscriptionStorageService';
 export { SubscriptionService } from './src/services/subscriptionService';
+export { YouTubeApiClient } from './src/services/youtubeApiClient';
 export { LikedVideoStorageService } from './src/services/likedVideoStorageService';
 export { setResponses, getRequestCount } from 'obsidian';`,
 			resolveDir: process.cwd(),
@@ -21,7 +23,7 @@ export { setResponses, getRequestCount } from 'obsidian';`,
 		plugins: [{
 			name: 'host-and-api-fixtures',
 			setup(context) {
-				context.onResolve({ filter: /^(obsidian|src\/auth|src\/debug)$/ }, args => ({ path: args.path, namespace: 'fixture' }));
+				context.onResolve({ filter: /^(obsidian|src\/debug)$/ }, args => ({ path: args.path, namespace: 'fixture' }));
 				context.onLoad({ filter: /.*/, namespace: 'fixture' }, ({ path: name }) => ({
 					contents: name === 'obsidian' ? `
 export const normalizePath = value => value.replace(/[\\\\/]+/g, '/');
@@ -31,15 +33,19 @@ export function getRequestCount() { return count; }
 export async function requestUrl(options) {
  const next = responses.shift(); count++;
  if (!next || !options.url.includes(next.path)) throw new Error('Unexpected API request');
- return { status: 200, json: next.body };
-}` : name === 'src/auth'
-						? 'export async function getValidAccessToken() { return "fixture-token"; }'
-						: 'export const debugLogger = { warn() {} };',
+ if (next.response) return next.response;
+ return { status: next.status ?? 200, json: next.body };
+}` : 'export const debugLogger = { api() {}, warn() {} };',
 				}));
 			},
 		}],
 	});
-	const { SubscriptionStorageService, SubscriptionService, LikedVideoStorageService, setResponses, getRequestCount } = await import(pathToFileURL(output).href);
+	const { SubscriptionStorageService, SubscriptionService, YouTubeApiClient, LikedVideoStorageService, setResponses, getRequestCount } = await import(pathToFileURL(output).href);
+	globalThis.window = {
+		setTimeout: globalThis.setTimeout.bind(globalThis),
+		clearTimeout: globalThis.clearTimeout.bind(globalThis),
+	};
+	const youtubeApiClient = new YouTubeApiClient(async () => 'fixture-token');
 	const adapter = {
 		exists: async p => { try { await access(p); return true; } catch (error) { if (error.code === 'ENOENT') return false; throw error; } },
 		read: p => readFile(p, 'utf8'),
@@ -81,14 +87,80 @@ export async function requestUrl(options) {
 			{ path: '/playlistItems?', body: { items: [{ contentDetails: { videoId: 'upcoming' } }] } },
 			{ path: '/videos?', body: { items: [structuredClone(video)] } },
 		]);
-		const service = new SubscriptionService({ googleClientId: 'fixture-client' }, storage);
+		const service = new SubscriptionService(youtubeApiClient, storage);
 		const result = await service.fetch();
 		assert.equal(result.videos.length, 1);
 		assert.equal(result.videos[0].contentDetails.duration, undefined);
 		assert.equal(getRequestCount(), 4);
-		const restarted = new SubscriptionService({ googleClientId: 'fixture-client' }, storage);
+		const restarted = new SubscriptionService(youtubeApiClient, storage);
 		await restarted.initialize();
 		assert.deepEqual(restarted.getSnapshot(), JSON.parse(JSON.stringify(result)));
+	});
+	await check('restart immediately after cancellation without reusing or committing the old request', async () => {
+		let resolveOldRequest;
+		const oldResponse = new Promise((resolve) => { resolveOldRequest = resolve; });
+		setResponses([
+			{ path: '/subscriptions?', response: oldResponse },
+			{ path: '/subscriptions?', body: { items: [{ id: 'new-subscription', snippet: { title: 'New channel', resourceId: { channelId: 'new-channel' } } }] } },
+			{ path: '/channels?', body: { items: [{ id: 'new-channel', contentDetails: { relatedPlaylists: { uploads: 'new-uploads' } } }] } },
+			{ path: '/playlistItems?', body: { items: [] } },
+		]);
+		const service = new SubscriptionService(youtubeApiClient, storage);
+		const oldController = new AbortController();
+		const oldProgress = [];
+		const oldFetch = service.fetch({
+			signal: oldController.signal,
+			onProgress: (progress) => oldProgress.push(progress),
+		});
+		await new Promise((resolve) => setImmediate(resolve));
+		oldController.abort();
+		const newFetch = service.fetch({ signal: new AbortController().signal });
+		assert.notEqual(oldFetch, newFetch);
+		await assert.rejects(oldFetch, (error) => error instanceof DOMException && error.name === 'AbortError');
+		const next = await newFetch;
+		assert.equal(next.channels[0].id, 'new-channel');
+		assert.equal(service.getSnapshot().channels[0].id, 'new-channel');
+		const progressCountAfterAbort = oldProgress.length;
+		resolveOldRequest({ status: 200, json: { items: [] } });
+		await new Promise((resolve) => setImmediate(resolve));
+		assert.equal(oldProgress.length, progressCountAfterAbort);
+		assert.equal(service.getSnapshot().channels[0].id, 'new-channel');
+	});
+	await check('preserve subscription failure policy from structured YouTube reasons', async () => {
+		setResponses([
+			{ path: '/subscriptions?', body: { items: [{ id: 'subscription', snippet: { title: 'Channel', resourceId: { channelId: 'channel' } } }] } },
+			{ path: '/channels?', body: { items: [{ id: 'channel', contentDetails: { relatedPlaylists: { uploads: 'uploads' } } }] } },
+			{
+				path: '/playlistItems?',
+				status: 403,
+				body: { error: { errors: [{ reason: 'forbidden' }] } },
+			},
+		]);
+		const service = new SubscriptionService(youtubeApiClient, storage);
+		const result = await service.fetch();
+		assert.equal(result.failedChannels[0].id, 'channel');
+		assert.equal(result.failureDetails.channel.retryable, false);
+		assert.match(result.failureDetails.channel.message, /denied access/);
+	});
+	await check('accept a 204 unsubscribe response and commit only the successful removal', async () => {
+		const subscribedSnapshot = {
+			...snapshot,
+			channels: [{ ...channel, subscriptionId: 'subscription' }],
+		};
+		await storage.save(subscribedSnapshot);
+		const service = new SubscriptionService(youtubeApiClient, storage);
+		await service.initialize();
+		setResponses([{
+			path: '/subscriptions?',
+			response: Promise.resolve({
+				status: 204,
+				get json() { throw new Error('No JSON body'); },
+			}),
+		}]);
+		const result = await service.unsubscribeChannels(subscribedSnapshot.channels);
+		assert.equal(result.succeededChannels.length, 1);
+		assert.equal(result.failedChannels.length, 0);
+		assert.equal(result.snapshot.channels.length, 0);
 	});
 	await check('liked-video persistence accepts the same upcoming broadcast', async () => {
 		const liked = new LikedVideoStorageService(adapter, root);

--- a/scripts/verifySubscriptionStorage.mjs
+++ b/scripts/verifySubscriptionStorage.mjs
@@ -126,6 +126,62 @@ export async function requestUrl(options) {
 		assert.equal(oldProgress.length, progressCountAfterAbort);
 		assert.equal(service.getSnapshot().channels[0].id, 'new-channel');
 	});
+	await check('keep memory and later operations aligned when cancellation happens during persistence', async () => {
+		let releaseFirstSave;
+		let markFirstSaveStarted;
+		let resolveNextSubscriptions;
+		let persisted = structuredClone(snapshot);
+		let saveCount = 0;
+		const firstSaveStarted = new Promise((resolve) => { markFirstSaveStarted = resolve; });
+		const firstSaveGate = new Promise((resolve) => { releaseFirstSave = resolve; });
+		const nextSubscriptions = new Promise((resolve) => { resolveNextSubscriptions = resolve; });
+		const controlledStorage = {
+			load: async () => structuredClone(persisted),
+			save: async (next) => {
+				saveCount += 1;
+				if (saveCount === 1) {
+					markFirstSaveStarted();
+					await firstSaveGate;
+				}
+				persisted = structuredClone(next);
+			},
+		};
+		const service = new SubscriptionService(youtubeApiClient, controlledStorage);
+		await service.initialize();
+		setResponses([
+			{ path: '/subscriptions?', body: { items: [{ id: 'persisted-subscription', snippet: { title: 'Persisted channel', resourceId: { channelId: 'persisted-channel' } } }] } },
+			{ path: '/channels?', body: { items: [{ id: 'persisted-channel', contentDetails: { relatedPlaylists: { uploads: 'persisted-uploads' } } }] } },
+			{ path: '/playlistItems?', body: { items: [] } },
+		]);
+		const stoppedController = new AbortController();
+		const stoppedFetch = service.fetch({ signal: stoppedController.signal });
+		await firstSaveStarted;
+		stoppedController.abort();
+
+		setResponses([
+			{ path: '/subscriptions?', response: nextSubscriptions },
+			{ path: '/channels?', body: { items: [{ id: 'next-channel', contentDetails: { relatedPlaylists: { uploads: 'next-uploads' } } }] } },
+			{ path: '/playlistItems?', body: { items: [] } },
+		]);
+		const nextFetch = service.fetch({ signal: new AbortController().signal });
+		await new Promise((resolve) => setImmediate(resolve));
+		assert.equal(getRequestCount(), 0);
+
+		releaseFirstSave();
+		await stoppedFetch;
+		assert.equal(service.getSnapshot().channels[0].id, 'persisted-channel');
+		assert.deepEqual(service.getSnapshot(), persisted);
+		await new Promise((resolve) => setImmediate(resolve));
+		assert.equal(getRequestCount(), 1);
+
+		resolveNextSubscriptions({
+			status: 200,
+			json: { items: [{ id: 'next-subscription', snippet: { title: 'Next channel', resourceId: { channelId: 'next-channel' } } }] },
+		});
+		const next = await nextFetch;
+		assert.equal(next.channels[0].id, 'next-channel');
+		assert.deepEqual(service.getSnapshot(), persisted);
+	});
 	await check('preserve subscription failure policy from structured YouTube reasons', async () => {
 		setResponses([
 			{ path: '/subscriptions?', body: { items: [{ id: 'subscription', snippet: { title: 'Channel', resourceId: { channelId: 'channel' } } }] } },

--- a/scripts/verifyYouTubeApiClient.mjs
+++ b/scripts/verifyYouTubeApiClient.mjs
@@ -1,0 +1,168 @@
+/* global globalThis */
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { build } from 'esbuild';
+
+const outputDirectory = await mkdtemp(path.join(tmpdir(), 'geulo-youtube-api-client-'));
+const outputPath = path.join(outputDirectory, 'youtube-api-client-verification.cjs');
+
+try {
+	await build({
+		stdin: {
+			contents: `export { YouTubeApiClient, YouTubeRequestError } from './src/services/youtubeApiClient.ts';`,
+			resolveDir: process.cwd(),
+		},
+		bundle: true,
+		format: 'cjs',
+		platform: 'node',
+		outfile: outputPath,
+		plugins: [{
+			name: 'youtube-api-client-fixtures',
+			setup(builder) {
+				builder.onResolve({ filter: /^(obsidian|src\/debug)$/ }, (args) => ({
+					path: args.path,
+					namespace: 'fixture',
+				}));
+				builder.onLoad({ filter: /.*/, namespace: 'fixture' }, ({ path: name }) => ({
+					contents: name === 'obsidian'
+						? `export const requestUrl = (request) => globalThis.requestUrl(request);`
+						: `export const debugLogger = { api() {} };`,
+					loader: 'js',
+				}));
+			},
+		}],
+	});
+
+	globalThis.window = {
+		setTimeout: globalThis.setTimeout.bind(globalThis),
+		clearTimeout: globalThis.clearTimeout.bind(globalThis),
+	};
+	const require = createRequire(import.meta.url);
+	const { YouTubeApiClient, YouTubeRequestError } = require(outputPath);
+	let tokenRequests = 0;
+	let requests = [];
+	let response = { status: 200, json: { items: [] } };
+	globalThis.requestUrl = async (request) => {
+		requests.push(request);
+		return response;
+	};
+	const client = new YouTubeApiClient(async () => {
+		tokenRequests += 1;
+		return 'access-token';
+	});
+
+	const ok = await client.request('GET', 'videos?part=id');
+	assert.equal(ok.status, 200);
+	assert.equal(tokenRequests, 1);
+	assert.equal(requests.length, 1);
+	assert.equal(requests[0].url, 'https://youtube.googleapis.com/youtube/v3/videos?part=id');
+	assert.equal(requests[0].headers.Authorization, 'Bearer access-token');
+
+	response = {
+		status: 204,
+		get json() {
+			throw new Error('No JSON body');
+		},
+	};
+	assert.equal((await client.request('DELETE', 'playlists?id=playlist')).status, 204);
+
+	response = {
+		status: 403,
+		json: { error: { message: 'Quota exhausted', errors: [{ reason: 'quotaExceeded' }] } },
+	};
+	await assert.rejects(
+		client.request('GET', 'playlists?mine=true'),
+		(error) => error instanceof YouTubeRequestError
+			&& error.kind === 'http'
+			&& error.status === 403
+			&& error.reasons.includes('quotaExceeded')
+			&& error.message === 'Quota exhausted',
+	);
+	response = {
+		status: 500,
+		get json() {
+			throw new Error('Invalid JSON');
+		},
+	};
+	await assert.rejects(
+		client.request('GET', 'videos'),
+		(error) => error instanceof YouTubeRequestError
+			&& error.status === 500
+			&& error.message === 'YouTube API request failed (500).',
+	);
+	response = { status: 401, json: { error: { message: 'Expired token' } } };
+	const requestsBeforeUnauthorized = requests.length;
+	await assert.rejects(
+		client.request('GET', 'videos'),
+		(error) => error instanceof YouTubeRequestError && error.kind === 'auth' && error.status === 401,
+	);
+	assert.equal(requests.length, requestsBeforeUnauthorized + 1);
+
+	const preAborted = new AbortController();
+	preAborted.abort();
+	const countsBeforeAbort = [tokenRequests, requests.length];
+	await assert.rejects(
+		client.request('GET', 'videos', { signal: preAborted.signal }),
+		(error) => error instanceof DOMException && error.name === 'AbortError',
+	);
+	assert.deepEqual([tokenRequests, requests.length], countsBeforeAbort);
+
+	let releaseToken;
+	const tokenWaitClient = new YouTubeApiClient(() => new Promise((resolve) => { releaseToken = resolve; }));
+	const tokenAbort = new AbortController();
+	const waitingForToken = tokenWaitClient.request('GET', 'videos', { signal: tokenAbort.signal });
+	tokenAbort.abort();
+	await assert.rejects(waitingForToken, (error) => error instanceof DOMException && error.name === 'AbortError');
+	const requestsBeforeRelease = requests.length;
+	releaseToken('late-token');
+	await new Promise((resolve) => setImmediate(resolve));
+	assert.equal(requests.length, requestsBeforeRelease);
+
+	let releaseTimedToken;
+	const originalSetTimeout = globalThis.window.setTimeout;
+	const originalClearTimeout = globalThis.window.clearTimeout;
+	globalThis.window.setTimeout = (callback) => {
+		queueMicrotask(callback);
+		return 1;
+	};
+	globalThis.window.clearTimeout = () => {};
+	const timeoutClient = new YouTubeApiClient(() => new Promise((resolve) => { releaseTimedToken = resolve; }));
+	await assert.rejects(
+		timeoutClient.request('GET', 'videos'),
+		(error) => error instanceof YouTubeRequestError && error.kind === 'timeout',
+	);
+	globalThis.window.setTimeout = originalSetTimeout;
+	globalThis.window.clearTimeout = originalClearTimeout;
+	const requestsBeforeTimedRelease = requests.length;
+	releaseTimedToken('late-token');
+	await new Promise((resolve) => setImmediate(resolve));
+	assert.equal(requests.length, requestsBeforeTimedRelease);
+
+	let releaseRequest;
+	globalThis.requestUrl = (request) => {
+		requests.push(request);
+		return new Promise((resolve) => { releaseRequest = resolve; });
+	};
+	const requestAbort = new AbortController();
+	const waitingForResponse = client.request('GET', 'videos', { signal: requestAbort.signal });
+	await new Promise((resolve) => setImmediate(resolve));
+	requestAbort.abort();
+	await assert.rejects(waitingForResponse, (error) => error instanceof DOMException && error.name === 'AbortError');
+	releaseRequest({ status: 200, json: { items: [] } });
+	await new Promise((resolve) => setImmediate(resolve));
+
+	globalThis.requestUrl = async () => { throw new Error('offline'); };
+	await assert.rejects(
+		client.request('GET', 'videos'),
+		(error) => error instanceof YouTubeRequestError && error.kind === 'network',
+	);
+	await assert.rejects(client.request('GET', 'https://example.com'), /relative path/);
+
+	console.log('youtube-api-client verification passed');
+} finally {
+	delete globalThis.requestUrl;
+	await rm(outputDirectory, { recursive: true, force: true });
+}

--- a/scripts/verifyYouTubeApiConsumers.mjs
+++ b/scripts/verifyYouTubeApiConsumers.mjs
@@ -1,0 +1,99 @@
+/* global globalThis */
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { build } from 'esbuild';
+
+const outputDirectory = await mkdtemp(path.join(tmpdir(), 'geulo-youtube-api-consumers-'));
+const outputPath = path.join(outputDirectory, 'youtube-api-consumers-verification.cjs');
+
+try {
+	await build({
+		stdin: {
+			contents: `
+				export { PlaylistApi, LikedVideoApi } from './src/api.ts';
+				export { YouTubeApiClient, YouTubeRequestError } from './src/services/youtubeApiClient.ts';
+			`,
+			resolveDir: process.cwd(),
+		},
+		bundle: true,
+		format: 'cjs',
+		platform: 'node',
+		outfile: outputPath,
+		plugins: [{
+			name: 'youtube-api-consumer-fixtures',
+			setup(builder) {
+				builder.onResolve({ filter: /^(obsidian|\.\/debug|src\/debug)$/ }, (args) => ({
+					path: args.path,
+					namespace: 'fixture',
+				}));
+				builder.onLoad({ filter: /.*/, namespace: 'fixture' }, ({ path: name }) => ({
+					contents: name === 'obsidian'
+						? `export const requestUrl = (request) => globalThis.requestUrl(request);`
+						: `export const debugLogger = { api() {}, error() {}, warn() {}, verbose() {} };`,
+					loader: 'js',
+				}));
+			},
+		}],
+	});
+
+	globalThis.window = {
+		setTimeout: globalThis.setTimeout.bind(globalThis),
+		clearTimeout: globalThis.clearTimeout.bind(globalThis),
+	};
+	const require = createRequire(import.meta.url);
+	const { PlaylistApi, LikedVideoApi, YouTubeApiClient, YouTubeRequestError } = require(outputPath);
+	const requests = [];
+	let responses = [];
+	globalThis.requestUrl = async (request) => {
+		requests.push(request);
+		const response = responses.shift();
+		if (!response) throw new Error('Unexpected request');
+		return response;
+	};
+	const client = new YouTubeApiClient(async () => 'shared-token');
+	const playlistApi = new PlaylistApi(client);
+	const likedVideoApi = new LikedVideoApi(client);
+
+	const forbidden = {
+		status: 403,
+		json: { error: { message: 'Denied', errors: [{ reason: 'forbidden' }] } },
+	};
+	responses = [forbidden, forbidden];
+	for (const request of [
+		playlistApi.fetchUserPlaylists(),
+		likedVideoApi.fetchLikedVideos(),
+	]) {
+		await assert.rejects(
+			request,
+			(error) => error instanceof YouTubeRequestError
+				&& error.status === 403
+				&& error.message === 'Denied'
+				&& error.reasons.includes('forbidden'),
+		);
+	}
+
+	responses = [
+		{ status: 200, json: { items: [] } },
+		{ status: 204, get json() { throw new Error('No JSON body'); } },
+		{ status: 204, get json() { throw new Error('No JSON body'); } },
+		{ status: 204, get json() { throw new Error('No JSON body'); } },
+		{ status: 204, get json() { throw new Error('No JSON body'); } },
+	];
+	assert.equal(await playlistApi.addVideoToPlaylist('playlist-id', 'video-id'), 'added');
+	await playlistApi.deletePlaylist('playlist-id');
+	await likedVideoApi.likeVideo('video-id');
+	await likedVideoApi.unlikeVideo('video-id');
+	assert.deepEqual(
+		requests.slice(-5).map((request) => request.method),
+		['GET', 'POST', 'DELETE', 'POST', 'POST'],
+	);
+	assert.ok(requests.slice(-5).every((request) => request.headers.Authorization === 'Bearer shared-token'));
+
+	console.log('youtube-api-consumers verification passed');
+} finally {
+	delete globalThis.requestUrl;
+	await rm(outputDirectory, { recursive: true, force: true });
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,13 +1,10 @@
-import { Notice, requestUrl } from "obsidian";
-import type { RequestUrlParam, RequestUrlResponse } from "obsidian";
-import { getGoogleAccessTokenFromLocal, getValidAccessToken } from "./auth";
-import { ObsidianGoogleLikedVideoSettings, YouTubeVideo, YouTubeVideosResponse, YouTubeCategory, YoutubeCategoriesResponse, PlaylistCache, YouTubePlaylistResponse, PlaylistSource, PaginatedResult, PlaylistInfo } from "./types";
+import type { RequestUrlResponse } from "obsidian";
+import { YouTubeVideo, YouTubeVideosResponse, YouTubeCategory, YoutubeCategoriesResponse, PlaylistCache, YouTubePlaylistResponse, PlaylistSource, PaginatedResult, PlaylistInfo } from "./types";
 import { debugLogger } from "./debug";
+import { YouTubeApiClient } from "./services/youtubeApiClient";
+import type { YouTubeRequestOptions } from "./services/youtubeApiClient";
 
-const BASE_URL = 'https://youtube.googleapis.com/youtube/v3/';
-const REQUEST_TIMEOUT_MS = 90000;
-
-type RequestOptions = Pick<RequestUrlParam, 'body' | 'contentType'>;
+type RequestOptions = Pick<YouTubeRequestOptions, 'body' | 'contentType'>;
 
 type PlaylistItemResponse = {
     snippet: {
@@ -21,31 +18,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null;
 }
 
-function isAbortError(error: unknown): boolean {
-    return error instanceof Error && error.name === 'AbortError';
-}
-
-function getErrorMessage(error: unknown): string {
-    return error instanceof Error ? error.message : String(error);
-}
-
-async function requestUrlWithTimeout(request: RequestUrlParam): Promise<RequestUrlResponse> {
-    let timeoutId: number | undefined;
-    const timeout = new Promise<never>((_, reject) => {
-        timeoutId = window.setTimeout(() => {
-            reject(new DOMException('Request timed out', 'AbortError'));
-        }, REQUEST_TIMEOUT_MS);
-    });
-
-    try {
-        return await Promise.race([requestUrl(request), timeout]);
-    } finally {
-        if (timeoutId !== undefined) {
-            window.clearTimeout(timeoutId);
-        }
-    }
-}
-
 // Generic Playlist API that can handle different playlist sources
 export class PlaylistApi {
 	private pendingPlaylistAdditions = new Set<string>();
@@ -53,7 +25,7 @@ export class PlaylistApi {
     private static readonly MAX_CACHE_SIZE = 50; // Maximum number of cached playlists
     private static readonly DEFAULT_TTL = 10 * 60 * 1000; // 10 minutes in milliseconds
 
-    constructor(private pluginSettings: ObsidianGoogleLikedVideoSettings) { }
+    constructor(private readonly client: YouTubeApiClient) { }
 
     /**
      * Cleanup resources when plugin is unloaded
@@ -96,52 +68,7 @@ export class PlaylistApi {
     }
 
     async sendRequest(method: 'GET' | 'POST' | 'DELETE', url: string, headers: Record<string, string>, options: RequestOptions = {}): Promise<RequestUrlResponse> {
-        let accessToken = getGoogleAccessTokenFromLocal();
-        debugLogger.api(`${method} request to: ${url}`);
-
-        try {
-            accessToken = await getValidAccessToken(
-                this.pluginSettings.googleClientId
-            );
-            const response = await requestUrlWithTimeout({
-                url,
-                method: method,
-                headers: {
-                    ...headers,
-                    'Authorization': `Bearer ${accessToken}`,
-                },
-                throw: false,
-                ...options,
-            });
-
-            debugLogger.api(`Response status: ${response.status}`);
-
-            // Handle different HTTP error types
-            if (response.status >= 400) {
-                let errorMessage = `HTTP ${response.status}`;
-
-                if (response.status === 403) {
-                    errorMessage = 'API quota exceeded or insufficient permissions';
-                } else if (response.status === 404) {
-                    errorMessage = 'Playlist not found or has been deleted';
-                } else if (response.status >= 500) {
-                    errorMessage = 'YouTube service temporarily unavailable';
-                }
-
-                throw new Error(errorMessage);
-            }
-
-            return response;
-        } catch (error: unknown) {
-            if (isAbortError(error)) {
-                debugLogger.error('Request timeout');
-                new Notice("Request timeout - please try again");
-                throw new Error('Request timeout - please try again');
-            }
-            debugLogger.error('API request failed:', error);
-            new Notice("API request failed: " + getErrorMessage(error));
-            throw error;
-        }
+        return this.client.request(method, url, { ...options, headers });
     }
 
     async fetchVideos(source: PlaylistSource, limit = 50, pageToken?: string): Promise<YouTubeVideosResponse> {
@@ -160,7 +87,7 @@ export class PlaylistApi {
     }
 
     private async fetchLikedVideos(limit: number, pageToken?: string): Promise<YouTubeVideosResponse> {
-        let url = BASE_URL + 'videos?'
+        let url = 'videos?'
             + 'part=snippet,contentDetails,statistics'
             + `&maxResults=${limit}`
             + '&myRating=like';
@@ -183,7 +110,7 @@ export class PlaylistApi {
 
 
     private async fetchPlaylistVideos(playlistId: string, limit: number, pageToken?: string): Promise<YouTubeVideosResponse> {
-        let url = BASE_URL + 'playlistItems?'
+        let url = 'playlistItems?'
             + 'part=snippet,contentDetails'
             + `&playlistId=${playlistId}`
             + `&maxResults=${limit}`;
@@ -226,7 +153,7 @@ export class PlaylistApi {
         }
 
         // Fetch detailed video information
-        const videosUrl = BASE_URL + 'videos?'
+        const videosUrl = 'videos?'
             + 'part=snippet,contentDetails,statistics'
             + `&id=${videoIds.join(',')}`;
 
@@ -266,7 +193,7 @@ export class PlaylistApi {
     }
 
 	async fetchUserPlaylists(): Promise<PlaylistInfo[]> {
-		const baseUrl = BASE_URL + 'playlists?'
+		const baseUrl = 'playlists?'
 			+ 'part=snippet,contentDetails'
 			+ '&maxResults=50'
 			+ '&mine=true';
@@ -308,7 +235,7 @@ export class PlaylistApi {
 		try {
 			// Check YouTube directly: a cached playlist may be incomplete or stale.
 			const params = new URLSearchParams({ part: 'id', playlistId, videoId, maxResults: '1' });
-			const response = await this.sendRequest('GET', `${BASE_URL}playlistItems?${params.toString()}`, {});
+			const response = await this.sendRequest('GET', `playlistItems?${params.toString()}`, {});
 			const data: unknown = response.json;
 			if (!isRecord(data) || !Array.isArray(data.items)) {
 				throw new Error('Could not check whether this video is already in the playlist. Please try again.');
@@ -318,7 +245,7 @@ export class PlaylistApi {
 				return 'already-exists';
 			}
 			try {
-				await this.sendRequest('POST', `${BASE_URL}playlistItems?part=snippet`, {}, {
+				await this.sendRequest('POST', 'playlistItems?part=snippet', {}, {
 					contentType: 'application/json',
 					body: JSON.stringify({ snippet: {
 						playlistId,
@@ -336,7 +263,7 @@ export class PlaylistApi {
 	}
 
     async deletePlaylist(playlistId: string): Promise<void> {
-        const url = BASE_URL + 'playlists?'
+        const url = 'playlists?'
             + `id=${encodeURIComponent(playlistId)}`;
 
         await this.sendRequest('DELETE', url, {});
@@ -349,7 +276,7 @@ export class PlaylistApi {
         // Clean playlist ID (remove URL parts if user pasted a full YouTube URL)
         const cleanPlaylistId = this.extractPlaylistId(playlistId);
 
-        const url = BASE_URL + 'playlists?'
+        const url = 'playlists?'
             + 'part=snippet,contentDetails'
             + `&id=${cleanPlaylistId}`;
 
@@ -605,9 +532,7 @@ export class PlaylistApi {
 }
 
 export class LikedVideoApi {
-    constructor(private pluginSettings: ObsidianGoogleLikedVideoSettings) {
-        this.pluginSettings = pluginSettings;
-    }
+    constructor(private readonly client: YouTubeApiClient) { }
 
     /**
      * Cleanup resources when plugin is unloaded
@@ -621,46 +546,12 @@ export class LikedVideoApi {
     // 2. If the access token is expired, it will refresh the access token with the refresh token
     // 3. It will add the access token to the request headers
     async sendRequest(method: 'GET' | 'POST', url: string, headers: Record<string, string>, options: RequestOptions = {}): Promise<RequestUrlResponse> {
-        let accessToken = getGoogleAccessTokenFromLocal();
-        debugLogger.api(`${method} request to: ${url}`);
-
-        try {
-            accessToken = await getValidAccessToken(
-                this.pluginSettings.googleClientId
-            );
-            const response = await requestUrl({
-                url,
-                method: method,
-                headers: {
-                    ...headers,
-                    'Authorization': `Bearer ${accessToken}`,
-                },
-                throw: false,
-                ...options
-            });
-            debugLogger.api(`Response status: ${response.status}`);
-
-            if (response.status >= 400) {
-                let errorMessage = `YouTube API request failed (${response.status})`;
-                if (isRecord(response.json)
-                    && isRecord(response.json.error)
-                    && typeof response.json.error.message === 'string') {
-                    errorMessage = response.json.error.message;
-                }
-                throw new Error(errorMessage);
-            }
-
-            return response;
-        } catch (error: unknown) {
-            debugLogger.error('API request failed:', error);
-            new Notice("YouTube API request failed: " + getErrorMessage(error));
-            throw error;
-        }
+        return this.client.request(method, url, { ...options, headers });
     }
 
     async fetchLikedVideos(limit = 50, pageToken?: string): Promise<YouTubeVideosResponse> {
         debugLogger.api(`Fetching liked videos - limit: ${limit}, pageToken: ${pageToken || 'none'}`);
-        let url = BASE_URL + 'videos?'
+        let url = 'videos?'
             + 'part=snippet,contentDetails,statistics'
             + `&maxResults=${limit}`
             + '&myRating=like';
@@ -681,7 +572,7 @@ export class LikedVideoApi {
     }
 
     async fetchPlaylists(): Promise<unknown> {
-        const url = BASE_URL + 'playlists?'
+        const url = 'playlists?'
             + 'part=snippet,contentDetails'
             + '&maxResults=5'
             + '&mine=true';
@@ -713,7 +604,7 @@ export class LikedVideoApi {
     }
 
     async fetchTotalLikedVideoCount(): Promise<number> {
-        const url = BASE_URL + 'videos?'
+        const url = 'videos?'
             + 'part=snippet,statistics'
             + '&maxResults=1'
             + '&myRating=like';
@@ -723,14 +614,14 @@ export class LikedVideoApi {
     }
 
     async likeVideo(videoId: string): Promise<void> {
-        const url = BASE_URL + 'videos/rate?id=' + videoId + '&rating=like';
+        const url = 'videos/rate?id=' + videoId + '&rating=like';
         await this.sendRequest('POST', url, {
             'Content-Type': 'application/json'
         });
     }
 
     async unlikeVideo(videoId: string): Promise<void> {
-        const url = BASE_URL + 'videos/rate?id=' + videoId + '&rating=none';
+        const url = 'videos/rate?id=' + videoId + '&rating=none';
         await this.sendRequest('POST', url, {
             'Content-Type': 'application/json'
         });
@@ -744,7 +635,7 @@ export class LikedVideoApi {
         try {
             debugLogger.api('Fetching video categories for US region');
 
-            const url = BASE_URL + 'videoCategories?part=snippet&regionCode=US';
+            const url = 'videoCategories?part=snippet&regionCode=US';
             const response = await this.sendRequest('GET', url, {});
             const data: YoutubeCategoriesResponse = response.json;
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -10,13 +10,27 @@ interface ServerSession {
 
 let serverSession: ServerSession | undefined;
 let serverSessionClose = Promise.resolve();
+let googleAuthVersion = 0;
+let latestRefreshId = 0;
+let activeRefresh: {
+	clientId: string;
+	refreshToken: string;
+	clientSecret: string;
+	promise: Promise<GoogleRefreshTokenResponse>;
+} | null = null;
 
 const PORT = 42813;
 const AUTH_REDIRECT_URI = `http://127.0.0.1:${PORT}/callback`;
+const REFRESH_TIMEOUT_MS = 90000;
 
 type GoogleOAuthTokenResponse = {
 	readonly access_token: string;
 	readonly refresh_token: string;
+	readonly expires_in: number;
+};
+
+type GoogleRefreshTokenResponse = {
+	readonly access_token: string;
 	readonly expires_in: number;
 };
 
@@ -29,6 +43,23 @@ function isGoogleOAuthTokenResponse(value: unknown): value is GoogleOAuthTokenRe
 		&& typeof value.access_token === 'string'
 		&& typeof value.refresh_token === 'string'
 		&& typeof value.expires_in === 'number';
+}
+
+function isGoogleRefreshTokenResponse(value: unknown): value is GoogleRefreshTokenResponse {
+	return isRecord(value)
+		&& typeof value.access_token === 'string'
+		&& value.access_token.length > 0
+		&& typeof value.expires_in === 'number'
+		&& Number.isFinite(value.expires_in)
+		&& value.expires_in > 0;
+}
+
+function invalidateGoogleAuth(): void {
+	googleAuthVersion += 1;
+	latestRefreshId += 1;
+	googleTokenStorageService.setRefreshToken("");
+	googleTokenStorageService.setAccessToken("");
+	localStorageService.setAccessTokenExpirationTime(0);
 }
 
 function closeServerSession(): Promise<void> {
@@ -63,9 +94,7 @@ export async function handleGoogleLogin(
 
 	await serverSessionClose;
 
-    googleTokenStorageService.setRefreshToken("");
-    googleTokenStorageService.setAccessToken("");
-    localStorageService.setAccessTokenExpirationTime(0);
+	invalidateGoogleAuth();
 
     const userClientID = pluginSettings.googleClientId;
     const userClientSecret = googleTokenStorageService.getClientSecret();
@@ -146,28 +175,24 @@ export async function handleGoogleLogout(
     pluginSettings: ObsidianGoogleLikedVideoSettings,
     onSuccess: () => void,
     onError: () => void,
-) {
+): Promise<void> {
     if (!Platform.isDesktop) {
         new Notice("Can't use this OAuth method on this device");
         return;
     }
 
     const accessToken = googleTokenStorageService.getAccessToken();
-    if (accessToken) {
-        const success = await revokeGoogleToken(accessToken);
-        googleTokenStorageService.setRefreshToken("");
-        googleTokenStorageService.setAccessToken("");
-        localStorageService.setAccessTokenExpirationTime(0);
-        localStorageService.setLikedVideos([]);
-        if (success) {
-            onSuccess();
-        } else {
-            onError();
-        }
+    const success = accessToken ? await revokeGoogleToken(accessToken) : true;
+    invalidateGoogleAuth();
+    localStorageService.setLikedVideos([]);
+    if (success) {
+        onSuccess();
+    } else {
+        onError();
     }
 }
 
-export async function revokeGoogleToken(token: string) {
+export async function revokeGoogleToken(token: string): Promise<boolean> {
     const revokeUrl = `https://oauth2.googleapis.com/revoke?token=${token}`;
     const response = await requestUrl({
         url: revokeUrl,
@@ -192,31 +217,61 @@ export async function refreshAccessToken(userClientId: string)
     const userClientSecret = googleTokenStorageService.getClientSecret();
 
     if (!refreshToken || refreshToken == "") {
-        new Notice("Refresh token for Google API is missing or expired");
         throw new Error("Refresh token for Google API is missing or expired");
     }
+	const clientId = userClientId.trim();
+	if (activeRefresh
+		&& activeRefresh.clientId === clientId
+		&& activeRefresh.refreshToken === refreshToken
+		&& activeRefresh.clientSecret === userClientSecret) {
+		return activeRefresh.promise;
+	}
+
+	const authVersion = googleAuthVersion;
+	const refreshId = ++latestRefreshId;
 
     const refreshTokenRequestBody = {
         grant_type: 'refresh_token',
         refresh_token: refreshToken,
-        client_id: userClientId,
+        client_id: clientId,
         client_secret: userClientSecret,
     }
 
-    const response = await requestUrl({
-        url: 'https://oauth2.googleapis.com/token',
-            method: 'POST',
-            headers: { 'content-type': 'application/json' },
-            body: JSON.stringify(refreshTokenRequestBody),
-    });
-
-    const token: { access_token: string, expires_in: number } = response.json;
-
-    googleTokenStorageService.setAccessToken(token.access_token);
-    localStorageService.setAccessTokenExpirationTime(+new Date() + token.expires_in * 1000);
-
-
-    return token;
+	let timeoutId: number | undefined;
+	const request = requestUrl({
+		url: 'https://oauth2.googleapis.com/token',
+		method: 'POST',
+		headers: { 'content-type': 'application/json' },
+		body: JSON.stringify(refreshTokenRequestBody),
+		throw: false,
+	});
+	const timeout = new Promise<never>((_, reject) => {
+		timeoutId = window.setTimeout(() => reject(new Error('Google token refresh timed out')), REFRESH_TIMEOUT_MS);
+	});
+	const refresh = (async (): Promise<GoogleRefreshTokenResponse> => {
+		try {
+			const response = await Promise.race([request, timeout]);
+			if (response.status >= 400) throw new Error(`Google token refresh failed (${response.status})`);
+			const token: unknown = response.json;
+			if (!isGoogleRefreshTokenResponse(token)) throw new Error('Google returned an invalid token response');
+			if (googleAuthVersion !== authVersion
+				|| latestRefreshId !== refreshId
+				|| googleTokenStorageService.getRefreshToken() !== refreshToken
+				|| googleTokenStorageService.getClientSecret() !== userClientSecret) {
+				throw new Error('Google authentication changed during token refresh');
+			}
+			googleTokenStorageService.setAccessToken(token.access_token);
+			localStorageService.setAccessTokenExpirationTime(Date.now() + token.expires_in * 1000);
+			return token;
+		} finally {
+			if (timeoutId !== undefined) window.clearTimeout(timeoutId);
+		}
+	})();
+	const trackedRefresh = refresh.finally(() => {
+		if (activeRefresh?.promise === trackedRefresh) activeRefresh = null;
+	});
+	activeRefresh = { clientId, refreshToken, clientSecret: userClientSecret, promise: trackedRefresh };
+	return trackedRefresh;
 }
 
 export async function getValidAccessToken(userClientId: string): Promise<string> {
@@ -232,20 +287,6 @@ export async function getValidAccessToken(userClientId: string): Promise<string>
     if (!accessToken) {
         const token = await refreshAccessToken(userClientId);
         return token.access_token;
-    }
-
-    return accessToken;
-}
-
-
-export function getGoogleAccessTokenFromLocal(): string {
-    const accessToken = googleTokenStorageService.getAccessToken();
-    /// Check if the access token is set
-    if (!accessToken || accessToken == "") {
-        new Notice(
-            "Access token for Google API is missing or expired"
-        );
-        return "";
     }
 
     return accessToken;

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { UserPlaylistsPane, VIEW_TYPE_USER_PLAYLISTS } from 'src/views/UserPlayl
 import { PlaylistVideosPane, VIEW_TYPE_PLAYLIST_VIDEOS } from 'src/views/PlaylistVideosPane';
 import { SubscriptionPane, VIEW_TYPE_SUBSCRIPTIONS } from 'src/views/SubscriptionPane';
 import { LikedVideoApi, PlaylistApi } from './api';
+import { getValidAccessToken } from './auth';
 import { localStorageService } from './storage';
 import { debugLogger } from './debug';
 import { UI_TEXT } from './constants/uiText';
@@ -26,6 +27,7 @@ import { SubscriptionService } from './services/subscriptionService';
 import { SubscriptionStorageService } from './services/subscriptionStorageService';
 import { vaultLocalStorageService } from './services/vaultLocalStorageService';
 import { VideoNoteIndexService } from './services/videoNoteIndexService';
+import { YouTubeApiClient } from './services/youtubeApiClient';
 
 const DEFAULT_SETTINGS: ObsidianGoogleLikedVideoSettings = {
 	googleClientId: '',
@@ -94,11 +96,14 @@ export default class GoogleLikedVideoPlugin extends Plugin {
 			debugLogger.error('[LikedVideoStorage] Failed to save liked-videos.json:', error);
 			new Notice('Geulo: Could not save the liked video list. Recent changes are only in memory. Check disk access before closing Obsidian.', 10000);
 		});
-		this.likedVideoApi = new LikedVideoApi(this.settings);
-		this.playlistApi = new PlaylistApi(this.settings);
-		this.commentService = new CommentService(this.settings);
+		const youtubeApiClient = new YouTubeApiClient(
+			() => getValidAccessToken(this.settings.googleClientId),
+		);
+		this.likedVideoApi = new LikedVideoApi(youtubeApiClient);
+		this.playlistApi = new PlaylistApi(youtubeApiClient);
+		this.commentService = new CommentService(youtubeApiClient);
 		const subscriptionStorage = new SubscriptionStorageService(this.app.vault.adapter, manifestDir);
-		this.subscriptionService = new SubscriptionService(this.settings, subscriptionStorage);
+		this.subscriptionService = new SubscriptionService(youtubeApiClient, subscriptionStorage);
 		try {
 			await this.subscriptionService.initialize();
 		} catch (error) {
@@ -443,6 +448,7 @@ export default class GoogleLikedVideoPlugin extends Plugin {
 		} catch (error) {
 			debugLogger.error('Auto-fetch failed:', error);
 			console.error('Auto-fetch failed:', error);
+			new Notice(`Geulo: Could not fetch liked videos. ${error instanceof Error ? error.message : 'Please try again.'}`);
 		} finally {
 			debugLogger.timeEnd('auto-fetch');
 			this.setFetchStatus('idle');

--- a/src/services/commentService.ts
+++ b/src/services/commentService.ts
@@ -1,9 +1,5 @@
-import { requestUrl } from "obsidian";
-import type { RequestUrlResponse } from "obsidian";
-import { getValidAccessToken } from "../auth";
-import type { ObsidianGoogleLikedVideoSettings } from "../types";
+import { YouTubeApiClient, YouTubeRequestError } from "./youtubeApiClient";
 
-const YOUTUBE_API_BASE_URL = "https://youtube.googleapis.com/youtube/v3/";
 export const COMMENT_LIMIT = 30;
 
 type JsonRecord = Record<string, unknown>;
@@ -90,54 +86,11 @@ function parseCommentThread(value: unknown): VideoComment | null {
 	};
 }
 
-function readApiErrorReason(value: unknown): string | undefined {
-	if (!isRecord(value) || !isRecord(value.error)) return undefined;
-	const errors = value.error.errors;
-	if (!Array.isArray(errors)) return undefined;
-	for (const error of errors) {
-		if (isRecord(error)) {
-			const reason = readString(error, "reason");
-			if (reason) return reason;
-		}
-	}
-	return undefined;
-}
-
-function createAbortError(): DOMException {
-	return new DOMException("Request aborted", "AbortError");
-}
-
-function requestComments(url: URL, accessToken: string, signal: AbortSignal): Promise<RequestUrlResponse> {
-	if (signal.aborted) return Promise.reject(createAbortError());
-
-	const request = requestUrl({
-		url: url.toString(),
-		method: "GET",
-		headers: { Authorization: `Bearer ${accessToken}` },
-		throw: false,
-	});
-
-	return new Promise((resolve, reject) => {
-		const abort = () => reject(createAbortError());
-		signal.addEventListener("abort", abort, { once: true });
-		void request.then(
-			(response) => {
-				signal.removeEventListener("abort", abort);
-				resolve(response);
-			},
-			(error: unknown) => {
-				signal.removeEventListener("abort", abort);
-				reject(error instanceof Error ? error : new Error("YouTube request failed"));
-			},
-		);
-	});
-}
-
 export class CommentService {
 	private myChannelIdPromise: Promise<string | null> | null = null;
 	private identityController: AbortController | null = null;
 
-	constructor(private readonly settings: ObsidianGoogleLikedVideoSettings) {}
+	constructor(private readonly client: YouTubeApiClient) {}
 
 	resetIdentityCache(): void {
 		this.identityController?.abort();
@@ -169,13 +122,14 @@ export class CommentService {
 	}
 
 	private async fetchTopLevelComments(videoId: string, signal: AbortSignal): Promise<readonly VideoComment[]> {
-		const url = new URL(YOUTUBE_API_BASE_URL + "commentThreads");
-		url.searchParams.set("part", "snippet");
-		url.searchParams.set("videoId", videoId);
-		url.searchParams.set("order", "relevance");
-		url.searchParams.set("maxResults", String(COMMENT_LIMIT));
-		url.searchParams.set("textFormat", "plainText");
-		const body = await this.get(url, signal);
+		const params = new URLSearchParams({
+			part: "snippet",
+			videoId,
+			order: "relevance",
+			maxResults: String(COMMENT_LIMIT),
+			textFormat: "plainText",
+		});
+		const body = await this.get(`commentThreads?${params.toString()}`, signal);
 		if (!isRecord(body) || !Array.isArray(body.items)) {
 			throw new CommentServiceError("invalid-response", "YouTube returned an invalid comments response.");
 		}
@@ -209,10 +163,8 @@ export class CommentService {
 	}
 
 	private async fetchMyChannelId(signal: AbortSignal): Promise<string | null> {
-		const url = new URL(YOUTUBE_API_BASE_URL + "channels");
-		url.searchParams.set("part", "id");
-		url.searchParams.set("mine", "true");
-		const body = await this.get(url, signal);
+		const params = new URLSearchParams({ part: "id", mine: "true" });
+		const body = await this.get(`channels?${params.toString()}`, signal);
 		if (!isRecord(body) || !Array.isArray(body.items)) {
 			throw new CommentServiceError("invalid-response", "YouTube returned an invalid channel response.");
 		}
@@ -225,28 +177,24 @@ export class CommentService {
 		return null;
 	}
 
-	private async get(url: URL, signal: AbortSignal): Promise<unknown> {
-		const accessToken = await getValidAccessToken(this.settings.googleClientId);
-		let response: RequestUrlResponse;
+	private async get(path: string, signal: AbortSignal): Promise<unknown> {
 		try {
-			response = await requestComments(url, accessToken, signal);
+			return (await this.client.request("GET", path, { signal })).json;
 		} catch (error) {
 			if (error instanceof DOMException && error.name === "AbortError") throw error;
+			if (error instanceof YouTubeRequestError) {
+				if (error.reasons.includes("commentsDisabled")) {
+					throw new CommentServiceError("comments-disabled", "Comments are disabled for this video.");
+				}
+				if (error.status === 404) {
+					throw new CommentServiceError("not-found", "This video is no longer available.");
+				}
+				if (error.status === 403) {
+					throw new CommentServiceError("forbidden", "YouTube could not return comments. Check your connection or API quota.");
+				}
+				throw new CommentServiceError("network", error.message);
+			}
 			throw new CommentServiceError("network", "Could not connect to YouTube.");
 		}
-
-		const body: unknown = response.json;
-		if (response.status >= 200 && response.status < 300) return body;
-		const reason = readApiErrorReason(body);
-		if (reason === "commentsDisabled") {
-			throw new CommentServiceError("comments-disabled", "Comments are disabled for this video.");
-		}
-		if (response.status === 404) {
-			throw new CommentServiceError("not-found", "This video is no longer available.");
-		}
-		if (response.status === 403) {
-			throw new CommentServiceError("forbidden", "YouTube could not return comments. Check your connection or API quota.");
-		}
-		throw new CommentServiceError("network", `YouTube request failed (${response.status}).`);
 	}
 }

--- a/src/services/subscriptionService.ts
+++ b/src/services/subscriptionService.ts
@@ -1,14 +1,11 @@
-import { requestUrl } from "obsidian";
-import { getValidAccessToken } from "src/auth";
 import type {
-	ObsidianGoogleLikedVideoSettings,
 	SubscriptionChannel,
 	YouTubeVideo,
 } from "src/types";
 import { debugLogger } from "src/debug";
 import { SubscriptionStorageService } from "./subscriptionStorageService";
+import { YouTubeApiClient, YouTubeRequestError } from "./youtubeApiClient";
 
-const BASE_URL = "https://youtube.googleapis.com/youtube/v3/";
 const CHANNEL_BATCH_SIZE = 50;
 const VIDEO_BATCH_SIZE = 50;
 const RECENT_VIDEOS_PER_CHANNEL = 5;
@@ -115,36 +112,29 @@ class SubscriptionRequestError extends Error {
 	}
 }
 
-function getYouTubeErrorReason(value: unknown): string | null {
-	if (typeof value !== "object" || value === null) return null;
-	const error = (value as Record<string, unknown>)["error"];
-	if (typeof error !== "object" || error === null) return null;
-	const errors = (error as Record<string, unknown>)["errors"];
-	if (!Array.isArray(errors)) return null;
-	const firstError = errors[0];
-	return typeof firstError === "object" && firstError !== null && "reason" in firstError
-		&& typeof firstError.reason === "string"
-		? firstError.reason
-		: null;
+function hasReason(error: YouTubeRequestError, ...reasons: string[]): boolean {
+	return error.reasons.some((reason) => reasons.includes(reason));
 }
 
-function getRequestFailure(status: number, body: unknown): SubscriptionFailureDetail {
-	const reason = getYouTubeErrorReason(body);
-	if (status === 401) return { message: "Google authentication expired.", retryable: true };
-	if (status === 404 || reason === "playlistNotFound") {
+function getRequestFailure(error: YouTubeRequestError): SubscriptionFailureDetail {
+	if (error.kind === "auth") return { message: "Google authentication expired.", retryable: true };
+	if (error.kind === "network" || error.kind === "timeout") {
+		return { message: error.message, retryable: true };
+	}
+	if (error.status === 404 || hasReason(error, "playlistNotFound")) {
 		return { message: "The channel's uploads playlist is unavailable.", retryable: false };
 	}
-	if (status === 403) {
-		const quotaExceeded = reason === "quotaExceeded" || reason === "dailyLimitExceeded";
+	if (error.status === 403) {
+		const quotaExceeded = hasReason(error, "quotaExceeded", "dailyLimitExceeded");
 		return {
 			message: quotaExceeded ? "YouTube API quota is currently exhausted." : "YouTube denied access to the uploads playlist.",
 			retryable: quotaExceeded,
 		};
 	}
-	if (status === 429 || status >= 500) {
+	if (error.status === 429 || (error.status !== undefined && error.status >= 500)) {
 		return { message: "YouTube is temporarily unavailable.", retryable: true };
 	}
-	return { message: `YouTube API request failed (${status}).`, retryable: false };
+	return { message: error.message, retryable: false };
 }
 
 function getFailureDetail(error: unknown): SubscriptionFailureDetail {
@@ -157,14 +147,16 @@ function getFailureDetail(error: unknown): SubscriptionFailureDetail {
 	};
 }
 
-function getDeleteFailure(status: number, body: unknown): SubscriptionFailureDetail {
-	const reason = getYouTubeErrorReason(body);
-	if (status === 401) return { message: "Google authentication expired.", retryable: true };
-	if (status === 404 || reason === "subscriptionNotFound") {
+function getDeleteFailure(error: YouTubeRequestError): SubscriptionFailureDetail {
+	if (error.kind === "auth") return { message: "Google authentication expired.", retryable: true };
+	if (error.kind === "network" || error.kind === "timeout") {
+		return { message: error.message, retryable: true };
+	}
+	if (error.status === 404 || hasReason(error, "subscriptionNotFound")) {
 		return { message: "The YouTube subscription could not be found.", retryable: false };
 	}
-	if (status === 403) {
-		const quotaExceeded = reason === "quotaExceeded" || reason === "dailyLimitExceeded";
+	if (error.status === 403) {
+		const quotaExceeded = hasReason(error, "quotaExceeded", "dailyLimitExceeded");
 		return {
 			message: quotaExceeded
 				? "YouTube API quota is currently exhausted."
@@ -172,18 +164,19 @@ function getDeleteFailure(status: number, body: unknown): SubscriptionFailureDet
 			retryable: quotaExceeded,
 		};
 	}
-	if (status === 429 || status >= 500) {
+	if (error.status === 429 || (error.status !== undefined && error.status >= 500)) {
 		return { message: "YouTube is temporarily unavailable.", retryable: true };
 	}
-	return { message: `YouTube API request failed (${status}).`, retryable: false };
+	return { message: error.message, retryable: false };
 }
 
 export class SubscriptionService {
 	private snapshot: SubscriptionSnapshot | null = null;
-	private activeRequest: Promise<SubscriptionSnapshot> | null = null;
+	private activeRequest: { promise: Promise<SubscriptionSnapshot>; signal?: AbortSignal } | null = null;
+	private commitQueue: Promise<void> = Promise.resolve();
 
 	constructor(
-		private readonly settings: ObsidianGoogleLikedVideoSettings,
+		private readonly client: YouTubeApiClient,
 		private readonly storage: SubscriptionStorageService,
 	) {}
 
@@ -201,12 +194,12 @@ export class SubscriptionService {
 	}
 
 	fetch(options: FetchOptions = {}): Promise<SubscriptionSnapshot> {
-		if (this.activeRequest) return this.activeRequest;
+		if (this.activeRequest && !this.activeRequest.signal?.aborted) return this.activeRequest.promise;
 
 		const request = this.fetchInternal(options).finally(() => {
-			if (this.activeRequest === request) this.activeRequest = null;
+			if (this.activeRequest?.promise === request) this.activeRequest = null;
 		});
-		this.activeRequest = request;
+		this.activeRequest = { promise: request, signal: options.signal };
 		return request;
 	}
 
@@ -229,6 +222,7 @@ export class SubscriptionService {
 			channels: retryableFailures,
 			commit: false,
 		});
+		throwIfAborted(options.signal);
 		const videosById = new Map(current.videos.map((video) => [video.id, video]));
 		retried.videos.forEach((video) => videosById.set(video.id, video));
 		const failureDetails = { ...retried.failureDetails };
@@ -286,23 +280,17 @@ export class SubscriptionService {
 		return { snapshot: nextSnapshot, succeededChannels, failedChannels };
 	}
 
-	private async request<T>(path: string, accessToken: string, signal?: AbortSignal): Promise<T> {
-		throwIfAborted(signal);
-		const response = await requestUrl({
-			url: BASE_URL + path,
-			method: "GET",
-			headers: { Authorization: `Bearer ${accessToken}` },
-			throw: false,
-		});
-		if (response.status >= 400) {
-			const failure = getRequestFailure(response.status, response.json);
+	private async request<T>(path: string, signal?: AbortSignal): Promise<T> {
+		try {
+			return (await this.client.request("GET", path, { signal })).json as T;
+		} catch (error) {
+			if (!(error instanceof YouTubeRequestError)) throw error;
+			const failure = getRequestFailure(error);
 			throw new SubscriptionRequestError(failure.message, failure.retryable);
 		}
-		return response.json as T;
 	}
 
 	private async findSubscriptionId(channelId: string): Promise<string | null> {
-		const accessToken = await getValidAccessToken(this.settings.googleClientId);
 		const params = new URLSearchParams({
 			part: "id,snippet",
 			mine: "true",
@@ -311,31 +299,25 @@ export class SubscriptionService {
 		});
 		const data = await this.request<ListResponse<SubscriptionItem>>(
 			`subscriptions?${params.toString()}`,
-			accessToken,
 		);
 		return data.items?.find((item) => item.snippet?.resourceId?.channelId === channelId)?.id ?? null;
 	}
 
 	private async deleteSubscription(subscriptionId: string): Promise<void> {
-		const accessToken = await getValidAccessToken(this.settings.googleClientId);
 		const params = new URLSearchParams({ id: subscriptionId });
-		const response = await requestUrl({
-			url: `${BASE_URL}subscriptions?${params.toString()}`,
-			method: "DELETE",
-			headers: { Authorization: `Bearer ${accessToken}` },
-			throw: false,
-		});
-		if (response.status >= 400) {
-			const failure = getDeleteFailure(response.status, response.json);
+		try {
+			await this.client.request("DELETE", `subscriptions?${params.toString()}`);
+		} catch (error) {
+			if (!(error instanceof YouTubeRequestError)) throw error;
+			const failure = getDeleteFailure(error);
 			throw new SubscriptionRequestError(failure.message, failure.retryable);
 		}
 	}
 
 	private async fetchInternal(options: FetchOptions): Promise<SubscriptionSnapshot> {
 		throwIfAborted(options.signal);
-		const accessToken = await getValidAccessToken(this.settings.googleClientId);
+		const channels = options.channels ?? await this.fetchChannels(options.signal);
 		throwIfAborted(options.signal);
-		const channels = options.channels ?? await this.fetchChannels(accessToken, options.signal);
 		options.onProgress?.({ completedChannels: 0, totalChannels: channels.length });
 
 		const videoIds = new Set<string>();
@@ -345,7 +327,7 @@ export class SubscriptionService {
 		await forEachConcurrent(channels, CHANNEL_UPLOADS_CONCURRENCY, async (channel) => {
 			throwIfAborted(options.signal);
 			try {
-				const ids = await this.fetchRecentVideoIds(channel, accessToken, options.signal);
+				const ids = await this.fetchRecentVideoIds(channel, options.signal);
 				ids.forEach((id) => videoIds.add(id));
 			} catch (error) {
 				if (options.signal?.aborted) throw error;
@@ -353,13 +335,15 @@ export class SubscriptionService {
 				failureDetails[channel.id] = getFailureDetail(error);
 				debugLogger.warn(`Failed to fetch subscription channel ${channel.id}:`, error);
 			} finally {
-				completedChannels += 1;
-				options.onProgress?.({ completedChannels, totalChannels: channels.length });
+				if (!options.signal?.aborted) {
+					completedChannels += 1;
+					options.onProgress?.({ completedChannels, totalChannels: channels.length });
+				}
 			}
 		});
 		throwIfAborted(options.signal);
 
-		const videos = await this.fetchVideoDetails([...videoIds], accessToken, options.signal);
+		const videos = await this.fetchVideoDetails([...videoIds], options.signal);
 		if (options.channels === undefined && this.snapshot && failedChannels.length > 0) {
 			const failedChannelIds = new Set(failedChannels.map((channel) => channel.id));
 			for (const video of this.snapshot.videos) {
@@ -379,16 +363,22 @@ export class SubscriptionService {
 			failureDetails,
 			updatedAt: Date.now(),
 		};
-		if (options.commit !== false) await this.commitSnapshot(nextSnapshot);
+		throwIfAborted(options.signal);
+		if (options.commit !== false) await this.commitSnapshot(nextSnapshot, options.signal);
 		return nextSnapshot;
 	}
 
-	private async commitSnapshot(snapshot: SubscriptionSnapshot): Promise<void> {
-		await this.storage.save(snapshot);
-		this.snapshot = snapshot;
+	private async commitSnapshot(snapshot: SubscriptionSnapshot, signal?: AbortSignal): Promise<void> {
+		const commit = this.commitQueue.then(async () => {
+			throwIfAborted(signal);
+			await this.storage.save(snapshot);
+			if (!signal?.aborted) this.snapshot = snapshot;
+		});
+		this.commitQueue = commit.catch(() => {});
+		await commit;
 	}
 
-	private async fetchChannels(accessToken: string, signal?: AbortSignal): Promise<SubscriptionChannel[]> {
+	private async fetchChannels(signal?: AbortSignal): Promise<SubscriptionChannel[]> {
 		const subscriptions: Array<{
 			id: string;
 			title: string;
@@ -405,7 +395,6 @@ export class SubscriptionService {
 			if (pageToken) params.set("pageToken", pageToken);
 			const data = await this.request<ListResponse<SubscriptionItem>>(
 				`subscriptions?${params.toString()}`,
-				accessToken,
 				signal,
 			);
 			for (const item of data.items ?? []) {
@@ -432,7 +421,6 @@ export class SubscriptionService {
 			});
 			const data = await this.request<ListResponse<ChannelItem>>(
 				`channels?${params.toString()}`,
-				accessToken,
 				signal,
 			);
 			for (const item of data.items ?? []) {
@@ -449,7 +437,6 @@ export class SubscriptionService {
 
 	private async fetchRecentVideoIds(
 		channel: SubscriptionChannel,
-		accessToken: string,
 		signal?: AbortSignal,
 	): Promise<string[]> {
 		const params = new URLSearchParams({
@@ -459,7 +446,6 @@ export class SubscriptionService {
 		});
 		const data = await this.request<ListResponse<PlaylistItem>>(
 			`playlistItems?${params.toString()}`,
-			accessToken,
 			signal,
 		);
 		return (data.items ?? []).flatMap((item) => {
@@ -470,7 +456,6 @@ export class SubscriptionService {
 
 	private async fetchVideoDetails(
 		ids: string[],
-		accessToken: string,
 		signal?: AbortSignal,
 	): Promise<YouTubeVideo[]> {
 		const videos: YouTubeVideo[] = [];
@@ -483,7 +468,6 @@ export class SubscriptionService {
 			});
 			const data = await this.request<ListResponse<YouTubeVideo>>(
 				`videos?${params.toString()}`,
-				accessToken,
 				signal,
 			);
 			for (const video of data.items ?? []) {

--- a/src/services/subscriptionService.ts
+++ b/src/services/subscriptionService.ts
@@ -204,6 +204,8 @@ export class SubscriptionService {
 	}
 
 	async retryFailed(options: Omit<FetchOptions, "channels"> = {}): Promise<SubscriptionSnapshot> {
+		await this.commitQueue;
+		throwIfAborted(options.signal);
 		const current = this.snapshot;
 		if (!current || current.failedChannels.length === 0) {
 			return current ?? this.fetch(options);
@@ -244,6 +246,7 @@ export class SubscriptionService {
 	}
 
 	async unsubscribeChannels(channels: SubscriptionChannel[]): Promise<UnsubscribeResult> {
+		await this.commitQueue;
 		const current = this.snapshot;
 		if (!current) throw new Error("Subscriptions have not been loaded.");
 
@@ -315,6 +318,7 @@ export class SubscriptionService {
 	}
 
 	private async fetchInternal(options: FetchOptions): Promise<SubscriptionSnapshot> {
+		await this.commitQueue;
 		throwIfAborted(options.signal);
 		const channels = options.channels ?? await this.fetchChannels(options.signal);
 		throwIfAborted(options.signal);
@@ -372,7 +376,7 @@ export class SubscriptionService {
 		const commit = this.commitQueue.then(async () => {
 			throwIfAborted(signal);
 			await this.storage.save(snapshot);
-			if (!signal?.aborted) this.snapshot = snapshot;
+			this.snapshot = snapshot;
 		});
 		this.commitQueue = commit.catch(() => {});
 		await commit;

--- a/src/services/youtubeApiClient.ts
+++ b/src/services/youtubeApiClient.ts
@@ -1,0 +1,152 @@
+import { requestUrl } from "obsidian";
+import type { RequestUrlParam, RequestUrlResponse } from "obsidian";
+import { debugLogger } from "src/debug";
+
+const YOUTUBE_API_BASE_URL = "https://youtube.googleapis.com/youtube/v3/";
+export const YOUTUBE_REQUEST_TIMEOUT_MS = 90000;
+
+export type YouTubeRequestMethod = "GET" | "POST" | "DELETE";
+export type YouTubeRequestErrorKind = "http" | "network" | "timeout" | "auth";
+
+export interface YouTubeRequestOptions extends Pick<RequestUrlParam, "body" | "contentType" | "headers"> {
+	signal?: AbortSignal;
+	timeoutMs?: number;
+}
+
+export class YouTubeRequestError extends Error {
+	constructor(
+		readonly kind: YouTubeRequestErrorKind,
+		message: string,
+		readonly status?: number,
+		readonly reasons: readonly string[] = [],
+		readonly originalError?: unknown,
+	) {
+		super(message);
+		this.name = "YouTubeRequestError";
+	}
+}
+
+type AccessTokenProvider = () => Promise<string>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function createAbortError(): DOMException {
+	return new DOMException("Request aborted", "AbortError");
+}
+
+function readErrorBody(response: RequestUrlResponse): unknown {
+	try {
+		return response.json;
+	} catch {
+		return undefined;
+	}
+}
+
+function readGoogleError(body: unknown): { message?: string; reasons: string[] } {
+	if (!isRecord(body) || !isRecord(body.error)) return { reasons: [] };
+	const message = typeof body.error.message === "string" ? body.error.message : undefined;
+	const errors = body.error.errors;
+	if (!Array.isArray(errors)) return { message, reasons: [] };
+	const reasons = errors.flatMap((error) =>
+		isRecord(error) && typeof error.reason === "string" ? [error.reason] : [],
+	);
+	return { message, reasons };
+}
+
+function createHttpError(response: RequestUrlResponse): YouTubeRequestError {
+	const { message, reasons } = readGoogleError(readErrorBody(response));
+	return new YouTubeRequestError(
+		response.status === 401 ? "auth" : "http",
+		message ?? `YouTube API request failed (${response.status}).`,
+		response.status,
+		reasons,
+	);
+}
+
+export class YouTubeApiClient {
+	constructor(private readonly accessTokenProvider: AccessTokenProvider) {}
+
+	async request(
+		method: YouTubeRequestMethod,
+		path: string,
+		options: YouTubeRequestOptions = {},
+	): Promise<RequestUrlResponse> {
+		if (/^[a-z][a-z\d+.-]*:/i.test(path) || path.startsWith("//")) {
+			throw new Error("YouTube API requests require a relative path.");
+		}
+
+		const normalizedPath = path.replace(/^\/+/, "");
+		const signal = options.signal;
+		let stopReason: Error | null = signal?.aborted ? createAbortError() : null;
+		if (stopReason) throw stopReason;
+
+		let timeoutId: number | undefined;
+		let abortListener: (() => void) | undefined;
+		const stop = new Promise<never>((_, reject) => {
+			timeoutId = window.setTimeout(() => {
+				const error = new YouTubeRequestError("timeout", "YouTube request timed out.");
+				stopReason = error;
+				reject(error);
+			}, options.timeoutMs ?? YOUTUBE_REQUEST_TIMEOUT_MS);
+
+			if (signal) {
+				abortListener = () => {
+					const error = createAbortError();
+					stopReason = error;
+					reject(error);
+				};
+				signal.addEventListener("abort", abortListener, { once: true });
+			}
+		});
+
+		const throwIfStopped = (): void => {
+			if (stopReason) throw stopReason;
+		};
+
+		const operation = (async (): Promise<RequestUrlResponse> => {
+			let accessToken: string;
+			try {
+				accessToken = await this.accessTokenProvider();
+			} catch (error) {
+				throwIfStopped();
+				throw new YouTubeRequestError("auth", "Could not authenticate with Google.", undefined, [], error);
+			}
+			throwIfStopped();
+			if (!accessToken) {
+				throw new YouTubeRequestError("auth", "Google access token is unavailable.");
+			}
+
+			debugLogger.api(`${method} request to: ${normalizedPath}`);
+			let response: RequestUrlResponse;
+			try {
+				response = await requestUrl({
+					url: YOUTUBE_API_BASE_URL + normalizedPath,
+					method,
+					headers: {
+						...options.headers,
+						Authorization: `Bearer ${accessToken}`,
+					},
+					body: options.body,
+					contentType: options.contentType,
+					throw: false,
+				});
+			} catch (error) {
+				throwIfStopped();
+				throw new YouTubeRequestError("network", "Could not connect to YouTube.", undefined, [], error);
+			}
+			throwIfStopped();
+			debugLogger.api(`Response status: ${response.status}`);
+			if (response.status < 200 || response.status >= 300) throw createHttpError(response);
+			return response;
+		})();
+
+		try {
+			return await Promise.race([operation, stop]);
+		} finally {
+			if (timeoutId !== undefined) window.clearTimeout(timeoutId);
+			if (signal && abortListener) signal.removeEventListener("abort", abortListener);
+		}
+	}
+}

--- a/src/views/UserPlaylistsPane.tsx
+++ b/src/views/UserPlaylistsPane.tsx
@@ -10,6 +10,7 @@ import { Root, createRoot } from "react-dom/client";
 import { StrictMode } from "react";
 import { localStorageService } from "src/storage";
 import { PlaylistInfo } from "src/types";
+import { YouTubeRequestError } from "src/services/youtubeApiClient";
 import { confirmDangerousAction } from "src/utils/confirmationUtils";
 import GoogleLikedVideoPlugin from "../main";
 import { PluginContext } from "../store/pluginContext";
@@ -98,24 +99,20 @@ export class UserPlaylistsPane
 			// Load both user playlists from YouTube and saved playlists from local storage
 			const [userPlaylists, savedPlaylists] = await Promise.all([
 				this.plugin.playlistApi.fetchUserPlaylists().catch((error) => {
-					// Show user-friendly error message for authentication issues
-					if (
-						error.message.includes("403") ||
-						error.message.includes("quota")
-					) {
+					if (error instanceof YouTubeRequestError
+						&& error.reasons.some((reason) => reason === "quotaExceeded" || reason === "dailyLimitExceeded")) {
 						new Notice(
 							"YouTube API quota exceeded. Please try again later.",
 						);
-					} else if (
-						error.message.includes("401") ||
-						error.message.includes("token")
-					) {
+					} else if (error instanceof YouTubeRequestError && error.kind === "auth") {
 						new Notice(
 							"Authentication expired. Please refresh your login.",
 						);
+					} else if (error instanceof YouTubeRequestError && error.status === 403) {
+						new Notice("YouTube did not allow access to these playlists.");
 					} else {
 						new Notice(
-							`Failed to load YouTube playlists: ${error.message}`,
+							`Failed to load YouTube playlists: ${error instanceof Error ? error.message : "Unknown error"}`,
 						);
 					}
 					return [];


### PR DESCRIPTION
## Summary

- introduce a shared YouTube API client for authentication headers, request timeouts, cancellation, and structured HTTP errors
- migrate playlist, liked-video, subscription, and comment requests to the shared client
- serialize token refreshes and prevent stale refresh responses from restoring outdated authentication state
- preserve service-specific error mapping and fix subscription stop/immediate-restart isolation

## Verification

- `npm run build`
- `npx eslint .`
- all `scripts/verify*.mjs`
- `git diff --check`
- manual Obsidian QA for liked videos, comments, playlists, and subscriptions

## Notes

- no automatic 401 replay was added
- actual account mutations were not performed during manual QA; mutation and 204 behavior are covered by isolated fixtures
- unrelated existing UI and utility worktree changes are not included